### PR TITLE
[xen] the mirage package depends on cstruct for cstruct.cmxa and bigarra...

### DIFF
--- a/xen/META.in
+++ b/xen/META.in
@@ -1,5 +1,5 @@
 version = "@VERSION@"
 description = "Mirage Xen platform"
-archive(byte) = "bigarray.cma cstruct.cma oS.cma"
-archive(native) = "bigarray.cmxa cstruct.cmxa oS.cmxa"
-requires = "cstruct.syntax lwt lwt.syntax"
+archive(byte) = "oS.cma"
+archive(native) = "oS.cmxa"
+requires = "cstruct cstruct.syntax lwt lwt.syntax"


### PR DESCRIPTION
...y.cmxa

The package cstruct provides both bigarray and cstruct.

The package mirage (see other pull request) depends on these but doesn't provide them directly.

xenstore stubdom now builds! :)
