### PR TITLE
xen: installing mirage provides a virtual package 'xenctrl'

### DIFF
--- a/cmd
+++ b/cmd
@@ -60,12 +60,15 @@ compile() {
 # generate META file and invoke ${OCAMLFIND} installation
 install()  {
   sed -e "s/@VERSION@/${VERSION}/g" < META.in > _config/META
+  sed -e "s/@VERSION@/${VERSION}/g" < META.xenctrl.in > _config/META.xenctrl
+
   ${OCAMLFIND} remove ${NAME} || true
   t=`sed -e 's,^,_build/,g' < _build/${NAME}.all`
   if [ ! -z "${DESTDIR}" ]; then
     OCAMLFIND_FLAGS="${OCAMLFIND_FLAGS} -destdir ${DESTDIR}"
   fi
   ${OCAMLFIND} install ${OCAMLFIND_FLAGS} ${NAME} _config/META ${t}
+  ${OCAMLFIND} install ${OCAMLFIND_FLAGS} xenctrl _config/META.xenctrl
 }
 
 # tests also include the built syntax extensions (if any)


### PR DESCRIPTION
An xen device driver can now depend on 'xenctrl' and build both
in mirage and in Linux userspace.
