### PR TITLE
Replace linux pcap stubs accidentally lost in beefa72e97b1b55e0d2e4b214e...

### DIFF
--- a/unix/lib/tap_stubs_linux.c
+++ b/unix/lib/tap_stubs_linux.c
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2010 Anil Madhavapeddy <anil@recoil.org>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include <unistd.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <err.h>
+
+#include <caml/mlvalues.h>
+#include <caml/memory.h>
+#include <caml/alloc.h>
+#include <caml/fail.h>
+#include <net/if.h>
+#include <sys/ioctl.h>
+
+CAMLprim value
+pcap_opendev(value v_name) {
+  CAMLparam1(v_name);
+  
+  err(1, "pcap_opendev unimplemented");
+
+  CAMLreturn(Val_int(-1));
+}
+
+CAMLprim value
+pcap_get_buf_len(value v_fd) {
+  CAMLparam1(v_fd);
+  CAMLreturn(Val_int(4096));
+}
+


### PR DESCRIPTION
...8c411b65e097a2

The tuntap stubs have moved to the tuntap package.
