### PR TITLE
Add a 'make uninstall' target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,5 +21,8 @@ install:
 	chmod a+x $(DESTDIR)$(PREFIX)/bin/mir-run
 	cd $(OS) && $(MAKE) install
 
+uninstall:
+	cd $(OS) && $(MAKE) uninstall
+
 test:
 	cd $(OS) && $(MAKE) test

--- a/cmd
+++ b/cmd
@@ -74,6 +74,15 @@ install()  {
   fi
 }
 
+uninstall() {
+  if [ -e META.xenctrl.in ]; then
+    ${OCAMLFIND} remove xenctrl
+  fi
+  if [ -e META.in ]; then
+    ${OCAMLFIND} remove mirage
+  fi
+}
+
 # tests also include the built syntax extensions (if any)
 run_tests() {
   for test in ${TESTS}; do
@@ -92,6 +101,7 @@ case "$cmd" in
 conf*) configure ;;
 compile|build) compile ;;
 install) install ;;
+uninstall) uninstall ;;
 clean) clean ;;
 doc) doc ;;
 test) run_tests ;;

--- a/xen/Makefile
+++ b/xen/Makefile
@@ -16,5 +16,8 @@ install:
 	mkdir -p $(XEN_LIB)
 	for l in $(EXTRA); do cp _build/$$l $(XEN_LIB); done
 
+uninstall:
+	./cmd uninstall
+
 clean:
 	./cmd clean


### PR DESCRIPTION
Since we install a 'xenctrl' package in the xen backend but not the unix
one, we need to have a backend-specific uninstall to clean everything up.
