### PR TITLE
xen: set Sys.os_type to "Unix" instead of "xen"

### DIFF
--- a/xen/runtime/config/s.h
+++ b/xen/runtime/config/s.h
@@ -1,4 +1,4 @@
-#define OCAML_OS_TYPE "xen"
+#define OCAML_OS_TYPE "Unix"
 #define OCAML_STDLIB_DIR "/usr/local/lib/ocaml"
 #define POSIX_SIGNALS
 //#define HAS_GETRUSAGE

--- a/xen/runtime/include/caml.4.00.1/config.h
+++ b/xen/runtime/include/caml.4.00.1/config.h
@@ -28,7 +28,7 @@
 #undef ARCH_ALIGN_DOUBLE
 #undef ARCH_ALIGN_INT64
 #undef NONSTANDARD_DIV_MOD
-#define OCAML_OS_TYPE "xen"
+#define OCAML_OS_TYPE "Unix"
 #define OCAML_STDLIB_DIR "/usr/local/lib/ocaml"
 #define POSIX_SIGNALS
 //#define HAS_GETRUSAGE


### PR DESCRIPTION
The stdlib Filename module calls 'assert false' if it doesn't
recognise the os_type. Might as well be Unix.

Signed-off-by: David Scott dave.scott@eu.citrix.com
