### PR TITLE
Install runtime headers for mirage-xen.

### DIFF
--- a/xen/Makefile
+++ b/xen/Makefile
@@ -1,13 +1,17 @@
 .PHONY: all _config build install uninstall doc clean
 
-PKG_CONFIG_PATH = $(shell opam config var prefix)/lib/pkgconfig
+OPAM_PREFIX := $(shell opam config var prefix)
+
+PKG_CONFIG_PATH = $(OPAM_PREFIX)/lib/pkgconfig
 export PKG_CONFIG_PATH
 
 EXTRA=runtime/xencaml/libxencaml.a runtime/ocaml/libocaml.a
+EXTRA_HEADERS=runtime/config runtime/ocaml runtime/include
 
 OCAMLFIND ?= ocamlfind
 
 XEN_LIB = $(shell ocamlfind printconf destdir)/mirage-xen
+XEN_INCLUDE = $(OPAM_PREFIX)/include/mirage-xen
 
 all: build
 
@@ -20,11 +24,13 @@ build: _config
 
 install:
 	./cmd install
-	mkdir -p $(XEN_LIB)
+	mkdir -p $(XEN_LIB) $(XEN_INCLUDE)
 	for l in $(EXTRA); do cp _build/$$l $(XEN_LIB); done
+	cp -r $(EXTRA_HEADERS) $(XEN_INCLUDE)
 
 uninstall:
 	./cmd uninstall
+	rm -rf $(XEN_INCLUDE)
 
 doc: _config
 	./cmd doc


### PR DESCRIPTION
Now that Mirage contains only a very minimal libc, I'd like to suggest we install the headers for those libc functions and the OCaml runtime somewhere where C stubs can find it.

C code is going to be linked against the functions regardless---given that, it seems prudent to allow them to have access to their headers as well.  Otherwise, libraries will need to include their own libc definitions which may be incompatible or clash with those defined by the Mirage runtime.

This patch installs runtime headers into $(OPAM_PREFIX)/include/mirage-xen, alongside the minios headers.  With this change, I've successfully built an add-on module to mirage that exposes additional hypercalls via OCaml.
