### PR TITLE
Fix "infinite" delay when no timeouts are scheduled

### DIFF
--- a/xen/lib/main.ml
+++ b/xen/lib/main.ml
@@ -65,7 +65,7 @@ let run t =
         end else begin
           let timeout =
             match Time.select_next Clock.time with
-            |None -> 86400.0 (* one day = 24 * 60 * 60 s *)
+            |None -> Clock.time () +. 86400.0 (* one day = 24 * 60 * 60 s *)
             |Some tm -> tm
           in
           block_domain timeout;


### PR DESCRIPTION
Was passing an interval as a time.

Fixes https://github.com/mirage/mirage/issues/298
