### PR TITLE
Add some more C functions for the TLS libraries

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,7 @@
+trunk (unreleased):
+* [xen] Provide functions that C code often uses for asserts (abort, printf,
+  etc).
+
 2.0.0 (04-Nov-2014):
 * Remove dietlibc, libm and most of the include files, replacing them with
   external dependencies on Mini-OS and openlibm.

--- a/xen/runtime/xencaml/mini_libc.c
+++ b/xen/runtime/xencaml/mini_libc.c
@@ -52,6 +52,10 @@
 	return ret; \
     }
 
+void *stderr = NULL;
+void *stdout = NULL;
+void * __stack_chk_guard = NULL;
+
 char *getenv(const char *name)
 {
   printk("getenv(%s) -> null\n", name);
@@ -108,6 +112,44 @@ void out(buffer_t *f, const char *s, size_t l)
             *(f->buf++) = *(s++);
         --l;
     }
+}
+
+int fprintf(void *stream, const char *fmt, ...)
+{
+  va_list  args;
+  va_start(args, fmt);
+  print(0, fmt, args);
+  va_end(args);
+  return 1;
+}
+
+int printf(const char *fmt, ...)
+{
+  va_list args;
+  va_start(args, fmt);
+  print(0, fmt, args);
+  va_end(args);
+  return 1;
+}
+
+int fflush (void * stream)
+{
+  return 0;
+}
+
+void abort(void)
+{
+  printk("Abort called!\n");
+  do_exit();
+}
+
+void __assert_fail(const char *assertion,
+		   const char *file,
+		   unsigned int line,
+		   const char *function)
+{
+  printk("%s:%d: %s: Assertion %s failed\n", file, line, function, assertion);
+  abort();
 }
 
 #define ZEROPAD 1               /* pad with zero */


### PR DESCRIPTION
These are @hannesm's patches to Mini-OS, but moved to mirage-platform.
- printf and fprintf write to the Mini-OS console, if there is free
  space (note: they return 1 rather than the number of bytes written).
- stdout and stderr are defined (as NULL).
- fflush is provided (now returns 0).
- __stack_chk_guard is defined so stack protection can be used.
- __assert_fail and abort are provided.

These functions are useful because code often uses them in debug macros and similar. They help with the TLS C dependencies.
