### PR TITLE
Use monotonic time for events

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,6 @@
+trunk (unreleased):
+* [xen] Use monotonic time for timing events, not wall-clock time.
+
 2.0.0 (04-Nov-2014):
 * Remove dietlibc, libm and most of the include files, replacing them with
   external dependencies on Mini-OS and openlibm.

--- a/xen/lib/main.ml
+++ b/xen/lib/main.ml
@@ -23,7 +23,7 @@
 
 open Lwt
 
-external block_domain : float -> unit = "caml_block_domain"
+external block_domain : [`Time] Time.Monotonic.t -> unit = "caml_block_domain"
 
 let evtchn = Eventchn.init ()
 
@@ -52,7 +52,7 @@ let run t =
   let t = call_hooks enter_hooks <&> t in
   let rec aux () =
     Lwt.wakeup_paused ();
-    Time.restart_threads Clock.time;
+    Time.restart_threads Time.Monotonic.time;
     match Lwt.poll t with
     | Some () ->
         ()
@@ -64,8 +64,8 @@ let run t =
           aux ()
         end else begin
           let timeout =
-            match Time.select_next Clock.time with
-            |None -> Clock.time () +. 86400.0 (* one day = 24 * 60 * 60 s *)
+            match Time.select_next () with
+            |None -> Time.Monotonic.(time () + of_seconds 86400.0) (* one day = 24 * 60 * 60 s *)
             |Some tm -> tm
           in
           block_domain timeout;

--- a/xen/runtime/xencaml/clock_stubs.c
+++ b/xen/runtime/xencaml/clock_stubs.c
@@ -32,6 +32,13 @@ unix_gettimeofday(value v_unit)
   CAMLreturn(caml_copy_double((double) tp.tv_sec + (double) tp.tv_usec / 1e6));
 }
 
+CAMLprim value
+caml_get_monotonic_time(value v_unit)
+{
+  CAMLparam1(v_unit);
+  CAMLreturn(caml_copy_int64(NOW()));
+}
+
 static value alloc_tm(struct tm *tm)
 {
   value res;

--- a/xen/runtime/xencaml/main.c
+++ b/xen/runtime/xencaml/main.c
@@ -30,7 +30,7 @@ CAMLprim value
 caml_block_domain(value v_until)
 {
   CAMLparam1(v_until);
-  block_domain((s_time_t)(Double_val(v_until) * 1000000000));
+  block_domain((s_time_t)(Int64_val(v_until)));
   CAMLreturn(Val_unit);
 }
 


### PR DESCRIPTION
This avoids possible problems when wall-clock time is adjusted. Also, it's needed on x86 because monotonic time and wall-clock time aren't the same.

I noticed this in the trace viewer; sleeps of < 100ms were taking exactly 100ms. The reason is that we asked to sleep for much too long, but the 100ms timer interrupt would wake us up anyway.

Will add change log entry when other PRs have been applied, or we'll just get conflicts.
