### PR TITLE
Fix error handling in OS.Main.run

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,5 @@
 * Remove mirage-xen.pc file on uninstall
+* [xen] Report failure to Xen if a top-level exception escapes.
 
 2.1.2 (20-Dec-2014):
 

--- a/xen/lib/main.ml
+++ b/xen/lib/main.ml
@@ -73,11 +73,7 @@ let run t =
           MProf.Trace.note_resume ();
           aux ()
         end in
-  try
-    aux ()
-  with exn ->
-    Printf.printf "Top level exception: %s\n%!"
-      (Printexc.to_string exn)
+  aux ()
 
 let () = at_exit (fun () -> run (call_hooks exit_hooks))
 let at_exit f = ignore (Lwt_sequence.add_l f exit_hooks)


### PR DESCRIPTION
We printed the exception but returned unit, causing the unikernel to
exit cleanly. This didn't trigger the on_crash behaviour of preserving
the domain, meaning that the console output would be lost.

Instead, simply let the exception propagate back to the C code, which
already handles exceptions.

Note: on x86_64, Mini-OS tries to print a stack trace in do_exit for
some reason, which results in a "Page fault" message being printed
too, but that can be fixed separately.

See: https://github.com/mirage/xen-arm-builder/issues/46