### PR TITLE
Fix Xen compilation with `gcc 4.8+` by disabling the stack protector

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,8 @@
+2.2.1 (26-Jan-2015):
+* Fix Xen compilation with `gcc 4.8+` by disabling the stack protector
+  and `-fno-tree-loop-distribute-patterns` (not compatible with MiniOS).
+  These missing flags were a regression from 2.1.3, which did include them.
+
 2.2.0 (23-Jan-2015):
 
 This releases adds support for OCaml 4.02+ compilation, and changes the Xen

--- a/unix/_vars
+++ b/unix/_vars
@@ -1,5 +1,5 @@
 NAME=mirage
-VERSION=2.2.0
+VERSION=2.2.1
 DEPS="cstruct lwt lwt.unix io-page.unix io-page mirage-clock-unix"
 SYNTAX_DEPS="cstruct.syntax lwt.syntax"
 LIB="oS"

--- a/xen-ocaml/bindings/build.sh
+++ b/xen-ocaml/bindings/build.sh
@@ -6,7 +6,13 @@ pkg-config --print-errors --exists ${PKG_CONFIG_DEPS} || exit 1
 CFLAGS=`pkg-config --cflags mirage-xen-ocaml`
 MINIOS_CFLAGS=`pkg-config --cflags mirage-xen-minios mirage-xen-ocaml`
 
+# This extra flag only needed for gcc 4.8+
+GCC_MVER2=`gcc -dumpversion | cut -f2 -d.`
+if [ $GCC_MVER2 -ge 8 ]; then
+  EXTRA_CFLAGS="-fno-tree-loop-distribute-patterns -fno-stack-protector"
+fi
+
 CC=${CC:-cc}
-$CC -Wall -Wno-attributes ${MINIOS_CFLAGS} -c barrier_stubs.c eventchn_stubs.c exit_stubs.c gnttab_stubs.c  main.c page_stubs.c  sched_stubs.c start_info_stubs.c  xb_stubs.c
-$CC -Wall -Wno-attributes ${CFLAGS} -c atomic_stubs.c clock_stubs.c cstruct_stubs.c 
+$CC -Wall -Wno-attributes ${MINIOS_CFLAGS} ${EXTRA_CFLAGS} -c barrier_stubs.c eventchn_stubs.c exit_stubs.c gnttab_stubs.c main.c page_stubs.c sched_stubs.c start_info_stubs.c xb_stubs.c
+$CC -Wall -Wno-attributes ${CFLAGS} ${EXTRA_CFLAGS} -c atomic_stubs.c clock_stubs.c cstruct_stubs.c
 ar rcs libxencamlbindings.a *.o

--- a/xen-ocaml/core/build.sh
+++ b/xen-ocaml/core/build.sh
@@ -10,14 +10,20 @@ armv*)
   m_file="arm"
  ;;
 *)
-  ARCH_CFLAGS="-momit-leaf-frame-pointer -mfancy-math-387 -fno-tree-loop-distribute-patterns -fno-stack-protector"
+  ARCH_CFLAGS="-momit-leaf-frame-pointer -mfancy-math-387"
   m_file="x86_64"
   ;;
 esac
 
+# This extra flag only needed for gcc 4.8+
+GCC_MVER2=`gcc -dumpversion | cut -f2 -d.`
+if [ $GCC_MVER2 -ge 8 ]; then
+  EXTRA_CFLAGS="-fno-tree-loop-distribute-patterns -fno-stack-protector"
+fi
+
 CC=${CC:-cc}
 PWD=`pwd`
-CFLAGS="-Wno-attributes ${ARCH_CFLAGS} -DSYS_xen -USYS_linux \
+CFLAGS="-Wno-attributes ${ARCH_CFLAGS} ${EXTRA_CFLAGS} -DSYS_xen -USYS_linux \
   $(pkg-config --cflags $PKG_CONFIG_DEPS) \
   -I `opam config var prefix`/include/mirage-xen/include"
 

--- a/xen-ocaml/core/build.sh
+++ b/xen-ocaml/core/build.sh
@@ -6,18 +6,18 @@ PKG_CONFIG_DEPS="openlibm libminios-xen >= 0.5"
 pkg-config --print-errors --exists ${PKG_CONFIG_DEPS} || exit 1
 case `uname -m` in
 armv*)
-  ARCH_CFLAGS="-DTARGET_arm"
+  ARCH_CFLAGS=""
   m_file="arm"
  ;;
 *)
-  ARCH_CFLAGS="-DTARGET_amd64 -D__x86_64__ -momit-leaf-frame-pointer -mfancy-math-387"
+  ARCH_CFLAGS="-momit-leaf-frame-pointer -mfancy-math-387 -fno-tree-loop-distribute-patterns -fno-stack-protector"
   m_file="x86_64"
   ;;
 esac
 
 CC=${CC:-cc}
 PWD=`pwd`
-CFLAGS="-Wno-attributes -DSYS_xen -USYS_linux \
+CFLAGS="-Wno-attributes ${ARCH_CFLAGS} -DSYS_xen -USYS_linux \
   $(pkg-config --cflags $PKG_CONFIG_DEPS) \
   -I `opam config var prefix`/include/mirage-xen/include"
 

--- a/xen-posix/build.sh
+++ b/xen-posix/build.sh
@@ -15,7 +15,7 @@ esac
 # This extra flag only needed for gcc 4.8+
 GCC_MVER2=`gcc -dumpversion | cut -f2 -d.`
 if [ $GCC_MVER2 -ge 8 ]; then
-  EXTRA_CFLAGS=-fno-tree-loop-distribute-patterns
+  EXTRA_CFLAGS="-fno-tree-loop-distribute-patterns -fno-stack-protector"
 fi
 
 CC=${CC:-cc}

--- a/xen/_vars
+++ b/xen/_vars
@@ -1,5 +1,5 @@
 NAME=mirage
-VERSION=2.2.0
+VERSION=2.2.1
 DEPS="lwt cstruct xen-evtchn xen-gnt xenstore shared-memory-ring shared-memory-ring.lwt shared-memory-ring.xenstore shared-memory-ring.console mirage-types mirage-clock-xen io-page mirage-profile"
 SYNTAX_DEPS="lwt.syntax cstruct.syntax"
 LIB="oS"


### PR DESCRIPTION
and `-fno-tree-loop-distribute-patterns` (not compatible with MiniOS).

These missing flags were a regression from 2.1.3, which did include them.