### PR TITLE
Add generic hooks to mainloop

### DIFF
--- a/unix/lib/main.ml
+++ b/unix/lib/main.ml
@@ -31,3 +31,5 @@ let run t =
 let () = at_exit (fun () -> run (call_hooks exit_hooks))
 let at_exit f = ignore (Lwt_sequence.add_l f exit_hooks)
 let at_enter f = ignore (Lwt_sequence.add_l f enter_hooks)
+let at_exit_iter f = ignore (Lwt_sequence.add_r f Lwt_main.leave_iter_hooks)
+let at_enter_iter f = ignore (Lwt_sequence.add_r f Lwt_main.enter_iter_hooks)

--- a/unix/lib/main.mli
+++ b/unix/lib/main.mli
@@ -16,3 +16,5 @@
 
 val run : unit Lwt.t -> unit
 val at_enter : (unit -> unit Lwt.t) -> unit
+val at_exit_iter  : (unit -> unit) -> unit
+val at_enter_iter : (unit -> unit) -> unit

--- a/xen/lib/main.mli
+++ b/xen/lib/main.mli
@@ -16,3 +16,5 @@
 
 val run : unit Lwt.t -> unit
 val at_enter : (unit -> unit Lwt.t) -> unit
+val at_enter_iter : (unit -> unit) -> unit
+val at_exit_iter  : (unit -> unit) -> unit


### PR DESCRIPTION
Adds the interface to register hooks that are *always* called from the main loop, irrespective of the event source. Usable for hooking up background tasks which depend on generic activity, but not on any specific event source.

This facility is required for proper entropy support: it is used to gather (hopefully) not-quite-deterministic inter-event timings and to arrange for periodic entropy harvesting from other sources without unduly waking up an otherwise idle system.

The API mirrors `Lwt_main.enter_iter_hooks` / `Lwt_main.leave_iter_hooks`, except that for the sake of simplicity and abstraction, instead of the full `Lwt_sequence`, only the hook registration is exposed. On unix, it actually defers to the equivalent facility in `Lwt_main`; on xen, it implements it in a similar way.

The choice of handlers not returning an `Lwt.t` reflects the fact that these hooks are not going to be synchronized on, and should probably not take long anyway. It's also possible to start an lwt thread in them using `Lwt.async`.

Strictly speaking, the entropy business only needs the enter hook, but its dual is provided for completeness.

This is running in the BTC Piñata. No [nasal demons](http://www.catb.org/jargon/html/N/nasal-demons.html) were registered thus far.