### PR TITLE
Remove unused include directory

### DIFF
--- a/bindings/mirage-xen.pc
+++ b/bindings/mirage-xen.pc
@@ -1,12 +1,10 @@
 prefix=${pcfiledir}/../..
 exec_prefix=${prefix}
-includedir=${prefix}/include/mirage-xen/include
 libdir=${exec_prefix}/lib
 
 Name: mirage-xen
 Version: 2.0.1
 URL: https://github.com/mirage/mirage-platform/
 Description: Core platform libraries for Mirage on Xen
-Cflags: -I${includedir}
 Libs: 
 Requires: mirage-xen-ocaml-bindings


### PR DESCRIPTION
We were adding `${prefix}/include/mirage-xen/include` to the include path, but we no longer put anything here (see #138).