### PR TITLE
Fix warnings in Xen C code

### DIFF
--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -72,6 +72,8 @@ opam init
 
 opam install ${OPAM_PACKAGES}
 
+export OPAMVERBOSE=1
+
 eval `opam config env`
 make unix-build
 make unix-install

--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -73,6 +73,7 @@ opam init
 opam install ${OPAM_PACKAGES}
 
 export OPAMVERBOSE=1
+export CI_CFLAGS=-Werror
 
 eval `opam config env`
 make unix-build

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: c
 script: bash -ex .travis-ci.sh
+sudo: required
 env:
   - OCAML_VERSION=4.01.0 OPAM_VERSION=1.2.0
   - OCAML_VERSION=4.02.1 OPAM_VERSION=1.2.0

--- a/bindings/build.sh
+++ b/bindings/build.sh
@@ -13,6 +13,6 @@ if [ $GCC_MVER2 -ge 8 ]; then
 fi
 
 CC=${CC:-cc}
-$CC -Wall -Wno-attributes ${MINIOS_CFLAGS} ${EXTRA_CFLAGS} -c barrier_stubs.c eventchn_stubs.c exit_stubs.c gnttab_stubs.c main.c sched_stubs.c start_info_stubs.c xb_stubs.c
-$CC -Wall -Wno-attributes ${CFLAGS} ${EXTRA_CFLAGS} -c atomic_stubs.c clock_stubs.c cstruct_stubs.c
+$CC -Wall -Wno-attributes ${MINIOS_CFLAGS} ${EXTRA_CFLAGS} ${CI_CFLAGS} -c barrier_stubs.c eventchn_stubs.c exit_stubs.c gnttab_stubs.c main.c sched_stubs.c start_info_stubs.c xb_stubs.c
+$CC -Wall -Wno-attributes ${CFLAGS} ${EXTRA_CFLAGS} ${CI_CFLAGS} -c atomic_stubs.c clock_stubs.c cstruct_stubs.c
 ar rcs libxencamlbindings.a *.o

--- a/xen-ocaml/build.sh
+++ b/xen-ocaml/build.sh
@@ -23,7 +23,7 @@ fi
 
 CC=${CC:-cc}
 PWD=`pwd`
-CFLAGS="-Wno-attributes ${ARCH_CFLAGS} ${EXTRA_CFLAGS} -DSYS_xen -USYS_linux \
+CFLAGS="-Wall -Wno-attributes ${ARCH_CFLAGS} ${EXTRA_CFLAGS} -DSYS_xen -USYS_linux \
   $(pkg-config --cflags $PKG_CONFIG_DEPS) \
   -I `opam config var prefix`/include/mirage-xen/include"
 

--- a/xen-ocaml/build.sh
+++ b/xen-ocaml/build.sh
@@ -24,6 +24,7 @@ fi
 CC=${CC:-cc}
 PWD=`pwd`
 CFLAGS="-Wall -Wno-attributes ${ARCH_CFLAGS} ${EXTRA_CFLAGS} ${CI_CFLAGS} -DSYS_xen -USYS_linux \
+  -fno-builtin-fprintf \
   $(pkg-config --cflags $PKG_CONFIG_DEPS) \
   -I `opam config var prefix`/include/mirage-xen/include"
 

--- a/xen-ocaml/build.sh
+++ b/xen-ocaml/build.sh
@@ -24,7 +24,7 @@ fi
 CC=${CC:-cc}
 PWD=`pwd`
 CFLAGS="-Wall -Wno-attributes ${ARCH_CFLAGS} ${EXTRA_CFLAGS} ${CI_CFLAGS} -DSYS_xen -USYS_linux \
-  -fno-builtin-fprintf \
+  -fno-builtin-fprintf -DHAS_UNISTD \
   $(pkg-config --cflags $PKG_CONFIG_DEPS) \
   -I `opam config var prefix`/include/mirage-xen/include"
 

--- a/xen-ocaml/build.sh
+++ b/xen-ocaml/build.sh
@@ -23,7 +23,7 @@ fi
 
 CC=${CC:-cc}
 PWD=`pwd`
-CFLAGS="-Wall -Wno-attributes ${ARCH_CFLAGS} ${EXTRA_CFLAGS} -DSYS_xen -USYS_linux \
+CFLAGS="-Wall -Wno-attributes ${ARCH_CFLAGS} ${EXTRA_CFLAGS} ${CI_CFLAGS} -DSYS_xen -USYS_linux \
   $(pkg-config --cflags $PKG_CONFIG_DEPS) \
   -I `opam config var prefix`/include/mirage-xen/include"
 

--- a/xen-posix/build.sh
+++ b/xen-posix/build.sh
@@ -21,7 +21,7 @@ fi
 # TODO: remove -Wno-sign-compare
 CC=${CC:-cc}
 PWD=`pwd`
-CFLAGS="$EXTRA_CFLAGS -I ${PWD}/include/ -I ${PWD}/src/ \
+CFLAGS="$EXTRA_CFLAGS ${CI_CFLAGS} -I ${PWD}/include/ -I ${PWD}/src/ \
     -D__XEN_INTERFACE_VERSION__=0x00030205 -D__INSIDE_MINIOS__ \
     $(pkg-config --cflags $PKG_CONFIG_DEPS) \
     -Wextra -Wchar-subscripts -Wno-switch -Wno-unused -Wredundant-decls -Wall \

--- a/xen-posix/include/stdio.h
+++ b/xen-posix/include/stdio.h
@@ -18,7 +18,7 @@ FILE *fdopen (int fildes, const char *mode) __THROW;
 FILE *freopen (const char *path, const char *mode, FILE *stream) __THROW;
 
 int printf(const char *format, ...) __THROW __attribute__((__format__(__printf__,1,2)));
-#define fprintf(x,rest...) printk(rest)
+int fprintf(FILE *stream, const char *format, ...) __THROW __attribute__((__format__(__printf__,2,3)));
 int sprintf(char *str, const char *format, ...) __THROW __attribute__((__format__(__printf__,2,3)));
 int snprintf(char *str, size_t size, const char *format, ...) __THROW __attribute__((__format__(__printf__,3,4)));
 int asprintf(char **ptr, const char* format, ...) __THROW __attribute_malloc__ __attribute__((__format__(__printf__,2,3)));

--- a/xen-posix/include/string.h
+++ b/xen-posix/include/string.h
@@ -1,0 +1,8 @@
+#ifndef _XEN_POSIX_STRING_H
+#define _XEN_POSIX_STRING_H
+
+#include_next <string.h>
+
+char *strerror(int errnum);
+
+#endif /* _XEN_POSIX_STRING_H */

--- a/xen-posix/src/mini_libc.c
+++ b/xen-posix/src/mini_libc.c
@@ -324,3 +324,7 @@ unsupported_function_crash(gmtime);
 unsupported_function_crash(strtod);
 unsupported_function_crash(rename);
 unsupported_function_crash(strerror);
+
+unsupported_function_log(pid_t, getpid, 2);
+unsupported_function_log(pid_t, getppid, 1);
+

--- a/xen-posix/src/mini_libc.c
+++ b/xen-posix/src/mini_libc.c
@@ -57,6 +57,8 @@
 	return ret; \
     }
 
+#define UNUSED __attribute__((__unused__))
+
 void *stderr = NULL;
 void *stdout = NULL;
 void * __stack_chk_guard = NULL;
@@ -99,7 +101,7 @@ int atoi(const char *nptr)
   return simple_strtoul(nptr, NULL, 10);
 }
 
-int open64(const char *pathname, int flags, ...)
+int open64(const char *pathname, int flags UNUSED, ...)
 {
   printk("Attempt to open(%s)!\n", pathname);
   return -1;
@@ -119,7 +121,7 @@ void out(buffer_t *f, const char *s, size_t l)
     }
 }
 
-int fprintf(void *stream, const char *fmt, ...)
+int fprintf(void *stream UNUSED, const char *fmt, ...)
 {
   va_list  args;
   va_start(args, fmt);
@@ -137,7 +139,7 @@ int printf(const char *fmt, ...)
   return 1;
 }
 
-int fflush (void * stream)
+int fflush (void * stream UNUSED)
 {
   return 0;
 }
@@ -156,7 +158,7 @@ void abort(void)
 #define SPECIAL 32              /* 0x */
 #define LARGE   64              /* use 'ABCDEF' instead of 'abcdef' */
 
-char *minios_printf_render_float(char *buf, char *end, long double y, char fmt, char qualifier, int size, int precision, int type)
+char *minios_printf_render_float(char *buf, char *end, long double y, char fmt, char qualifier UNUSED, int size, int precision, int type)
 {
     buffer_t buffer = {
         .buf = buf,


### PR DESCRIPTION
Enable -Wall for xen-ocaml, and -Werror for xen-related builds under travis.
Resolve the remaining C warnings (missing prototypes).

@talex5 -- please let me know if anything needs improvement
