### PR TITLE
Don't show warnings about use of getenv and lseek

### DIFF
--- a/xen-posix/src/mini_libc.c
+++ b/xen-posix/src/mini_libc.c
@@ -63,9 +63,8 @@ void *stderr = NULL;
 void *stdout = NULL;
 void * __stack_chk_guard = NULL;
 
-char *getenv(const char *name)
+char *getenv(__attribute__((unused)) const char *name)
 {
-  printk("getenv(%s) -> null\n", name);
   return NULL;
 }
 
@@ -317,7 +316,7 @@ unsupported_function_crash(unlink);
 unsupported_function_crash(getcwd);
 unsupported_function_crash(system);
 unsupported_function_crash(close);
-unsupported_function_log(off_t, lseek, -1);
+unsupported_function(off_t, lseek, -1);
 unsupported_function_crash(fcntl);
 unsupported_function_crash(read);
 unsupported_function_crash(gmtime);


### PR DESCRIPTION
OCaml calls `lseek` at startup on stdin, stdout and stderr. It also checks for `OCAMLRUNPARAM`, `CAMLRUNPARAM`, `TMPDIR` and `TEMP` environment variables. No need for any warnings here.

Combined with the latest https://github.com/talex5/mini-os/commits/master this reduces the boot noise quite a bit...