### PR TITLE
xen: Custom boot message for MirageOS

### DIFF
--- a/bindings/main.c
+++ b/bindings/main.c
@@ -55,6 +55,11 @@ void app_main_thread(void *unused)
   _exit(0);
 }
 
+void minios_show_banner(void)
+{
+  printk("\x1b[32;1mMirageOS booting...\x1b[0m\n");
+}
+
 void start_kernel(void)
 {
   /* Set up events. */


### PR DESCRIPTION
Only does anything with minios-xen >= 0.8, but harmless on older versions.