### PR TITLE
Raise an exception if gntmap_map_grant_refs returns NULL

### DIFF
--- a/bindings/gnttab_stubs.c
+++ b/bindings/gnttab_stubs.c
@@ -97,7 +97,9 @@ stub_gnttab_unmap(value i, value v_handle)
   CAMLparam2(i, v_handle);
   unsigned long start_address = Int_val(Field(v_handle, 0));
   int count = Int_val(Field(v_handle, 1));
-  gntmap_munmap(map, start_address, count);
+  if (gntmap_munmap(map, start_address, count)) {
+    caml_failwith("gntmap_munmap failed");
+  }
 
   CAMLreturn(Val_unit);
 }

--- a/bindings/gnttab_stubs.c
+++ b/bindings/gnttab_stubs.c
@@ -111,7 +111,10 @@ CAMLprim value stub_gnttab_map_fresh(value i, value r, value d, value w)
     uint32_t refs[1];
     domids[0] = Int_val(d);
     refs[0] = Int_val(r);
-    mapping = gntmap_map_grant_refs(map, 1, domids, 1, refs, 1);
+    mapping = gntmap_map_grant_refs(map, 1, domids, 1, refs, Bool_val(w));
+    if (mapping==NULL) {
+            caml_failwith("stub_gnttab_map_fresh: failed to map grant ref");
+    }
 
     handle = caml_alloc_tuple(2);
     Store_field(handle, 0, Val_int(mapping)); /* FIXME: this is an unsigned long */
@@ -138,7 +141,7 @@ CAMLprim value stub_gnttab_mapv_batched(value xgh, value array, value writable)
     }
     void *mapping = gntmap_map_grant_refs(map, count, domids, 1, refs, Bool_val(writable));
     if(mapping==NULL) {
-            caml_failwith("Failed to map grant ref");
+            caml_failwith("stub_gnttab_mapv_batched: failed to map grant ref");
     }
     handle = caml_alloc_tuple(2);
     Store_field(handle, 0, Val_int(mapping)); /* FIXME: this is an unsigned long */


### PR DESCRIPTION
Before, we just started using memory at address 0.