### PR TITLE
Raise an exception if event channel creation fails

### DIFF
--- a/bindings/eventchn_stubs.c
+++ b/bindings/eventchn_stubs.c
@@ -22,6 +22,7 @@
 #include <caml/alloc.h>
 #include <caml/callback.h>
 #include <caml/bigarray.h>
+#include <caml/fail.h>
 
 #define NR_EVENTS 4096 /* max for x86_64 using old ABI */
 static uint8_t ev_callback_ml[NR_EVENTS];
@@ -128,7 +129,7 @@ stub_evtchn_alloc_unbound(value v_unit, value v_domid)
 
     rc = evtchn_alloc_unbound(domid, NULL, NULL, &port);
     if (rc)
-       CAMLreturn(Val_int(-1));
+       caml_failwith("evtchn_alloc_unbound");
     else
        CAMLreturn(Val_int(port)); 
 }
@@ -144,7 +145,7 @@ stub_evtchn_bind_interdomain(value v_unit, value v_domid, value v_remote_port)
 
     rc = evtchn_bind_interdomain(domid, remote_port, NULL, NULL, &local_port);
     if (rc)
-       CAMLreturn(Val_int(-1));
+       caml_failwith("evtchn_bind_interdomain");
     else
        CAMLreturn(Val_int(local_port)); 
 }


### PR DESCRIPTION
Before, we returned -1, which Eventchn treated as a valid channel ID.
Attempting to use this would typically cause a crash. e.g.

    ERROR: bind_interdomain failed with rc=-22
    Page fault at linear address 18001df968, rip fe9d0, regs 000000000021fac8, sp 21fb70, our_sp 000000000021fa90, code 0
    RIP: e030:[<00000000000fe9d0>]
    RSP: e02b:000000000021fb70  EFLAGS: 00010002
    RAX: 00000002fffffffd RBX: 00000000ffffffff RCX: 000000000140e000
    RDX: 0000000000000001 RSI: ffffffffffffffff RDI: 00000000ffffffff
    RBP: 00000000ffffffff R08: 000000000025f0b0 R09: 000000000021fa60
    R10: 000ffffffffff000 R11: 00000000001d7510 R12: 0000000000043e97
    R13: 00000000011e79b8 R14: 000000000021fc80 R15: 00000000011e3088
    base is 0xffffffff Page fault in pagetable walk (access to invalid memory?).

This patch makes the behaviour consistent with the Unix eventchn_stubs.c

Fixes https://github.com/mirage/ocaml-evtchn/issues/21.