### PR TITLE
allow packages to be built without `opam` command line tool

### DIFF
--- a/bindings/build.sh
+++ b/bindings/build.sh
@@ -1,8 +1,16 @@
 #!/bin/sh -ex
 
-export PKG_CONFIG_PATH=`opam config var prefix`/lib/pkgconfig
 PKG_CONFIG_DEPS="mirage-xen-minios mirage-xen-ocaml"
-pkg-config --print-errors --exists ${PKG_CONFIG_DEPS} || exit 1
+check_deps () {
+  pkg-config --print-errors --exists ${PKG_CONFIG_DEPS}
+}
+
+if ! check_deps 2>/dev/null; then
+  # only rely on `opam` if deps are unavailable
+  export PKG_CONFIG_PATH=`opam config var prefix`/lib/pkgconfig
+fi
+check_deps || exit 1
+
 CFLAGS=`pkg-config --cflags mirage-xen-ocaml`
 MINIOS_CFLAGS=`pkg-config --cflags mirage-xen-minios mirage-xen-ocaml`
 

--- a/bindings/install.sh
+++ b/bindings/install.sh
@@ -1,6 +1,6 @@
 #!/bin/sh -ex
 
-prefix=$1
+prefix=${1:-$PREFIX}
 if [ "$prefix" = "" ]; then
   prefix=`opam config var prefix`
 fi

--- a/xen-ocaml/build.sh
+++ b/xen-ocaml/build.sh
@@ -1,9 +1,17 @@
 #!/bin/sh -ex
 
 MJOBS=${4:-NJOBS}
-export PKG_CONFIG_PATH=`opam config var prefix`/lib/pkgconfig
 PKG_CONFIG_DEPS="mirage-xen-posix openlibm libminios-xen >= 0.5"
-pkg-config --print-errors --exists ${PKG_CONFIG_DEPS} || exit 1
+check_deps () {
+  pkg-config --print-errors --exists ${PKG_CONFIG_DEPS}
+}
+
+if ! check_deps 2>/dev/null; then
+  # only rely on `opam` if deps are unavailable
+  export PKG_CONFIG_PATH=`opam config var prefix`/lib/pkgconfig
+fi
+
+check_deps || exit 1
 case `uname -m` in
 armv*)
   ARCH_CFLAGS=""
@@ -29,7 +37,8 @@ CFLAGS="-Wall -Wno-attributes ${ARCH_CFLAGS} ${EXTRA_CFLAGS} ${CI_CFLAGS} -DSYS_
   -I `opam config var prefix`/include/mirage-xen/include"
 
 rm -rf ocaml-src
-cp -r `opam config var prefix`/lib/ocaml-src ocaml-src
+cp -r `ocamlfind query ocaml-src` ocaml-src
+chmod -R u+w ocaml-src
 
 case `ocamlopt -version` in
 4.01.* | 4.02.[01]) patch < trace-gc.patch -p 0

--- a/xen-ocaml/build.sh
+++ b/xen-ocaml/build.sh
@@ -34,7 +34,7 @@ PWD=`pwd`
 CFLAGS="-Wall -Wno-attributes ${ARCH_CFLAGS} ${EXTRA_CFLAGS} ${CI_CFLAGS} -DSYS_xen -USYS_linux \
   -fno-builtin-fprintf -DHAS_UNISTD \
   $(pkg-config --cflags $PKG_CONFIG_DEPS) \
-  -I `opam config var prefix`/include/mirage-xen/include"
+  "
 
 rm -rf ocaml-src
 cp -r `ocamlfind query ocaml-src` ocaml-src

--- a/xen-ocaml/install.sh
+++ b/xen-ocaml/install.sh
@@ -1,6 +1,6 @@
 #!/bin/sh -ex
 
-prefix=$1
+prefix=${1:-$PREFIX}
 if [ "$prefix" = "" ]; then
   prefix=`opam config var prefix`
 fi

--- a/xen-posix/build.sh
+++ b/xen-posix/build.sh
@@ -1,8 +1,15 @@
 #!/bin/sh -ex
 
-export PKG_CONFIG_PATH=`opam config var prefix`/lib/pkgconfig
 PKG_CONFIG_DEPS="openlibm libminios-xen >= 0.5"
-pkg-config --print-errors --exists ${PKG_CONFIG_DEPS} || exit 1
+check_deps () {
+  pkg-config --print-errors --exists ${PKG_CONFIG_DEPS}
+}
+
+if ! check_deps 2>/dev/null; then
+  # only rely on `opam` if deps are unavailable
+  export PKG_CONFIG_PATH=`opam config var prefix`/lib/pkgconfig
+fi
+check_deps || exit 1
 
 case `uname -m` in
 armv*)

--- a/xen-posix/install.sh
+++ b/xen-posix/install.sh
@@ -1,6 +1,6 @@
 #!/bin/sh -ex
 
-prefix=$1
+prefix=${1:-$PREFIX}
 if [ "$prefix" = "" ]; then
   prefix=`opam config var prefix`
 fi


### PR DESCRIPTION
Rebased version of #144:

> In order to build in `opam2nix`, I've modified the build / install scripts to accept already-available dependencies (in PKG_CONFIG_PATH), already-configured destination (in $PREFIX), and ocamlfindable dependencies (rather than assuming they live in `opam config var prefix`/lib/name).
> 
> This change would also need some associated `opam` changes:
> 
>  - xen-ocaml now depends on `ocamlfind`, since it uses it to find opal-src
>  - opam-src needs to contain a META file (it doesn't need to specify anything other than a version, though)
> 
> There may be a better way of making `ocaml-src` findable, e.g. by using opam variables instead of relying on `ocamlfind`.

Fixes #144