### PR TITLE
Avoid raising an exception in an at_exit handler

### DIFF
--- a/unix/lib/main.ml
+++ b/unix/lib/main.ml
@@ -23,7 +23,10 @@ open Printf
    when timeouts expire. Thus, the program may only call this function
    once and once only. *)
 let run t =
-  Sys.(set_signal sigpipe Signal_ignore);
+  (* If the platform doesn't have SIGPIPE, then Sys.set_signal will
+     raise an Invalid_argument exception. If the signal does not exist
+     then we don't need to ignore it, so it's safe to continue. *)
+  (try Sys.(set_signal sigpipe Signal_ignore) with Invalid_argument _ -> ());
   let t = call_hooks enter_hooks <&> t in
   Lwt_unix.run t
 


### PR DESCRIPTION
Before this patch linking mirage-unix on Windows would register the
at_exit handler, which would attempt to ignore SIGPIPE on exit, which
would raise an exception because the signal is not supported by the
platform.

If a platform does not support SIGPIPE, it does not matter if attempts
to ignore the exception fail.

Signed-off-by: David Scott <dave@recoil.org>