### PR TITLE
mirage-{unix,xen}: fix typos in opam license field

### DIFF
--- a/mirage-unix.opam
+++ b/mirage-unix.opam
@@ -4,7 +4,7 @@ authors:      "The MirageOS team"
 homepage:     "https://github.com/mirage/mirage-platform"
 bug-reports:  "https://github.com/mirage/mirage-platform/issues/"
 dev-repo:     "https://github.com/mirage/mirage-platform.git"
-license:      "part ISC, part LBPL-2.1 with OCaml linking ecxeption, part 3-clause BSD"
+license:      "part ISC, part LGPL-2.1 with OCaml linking exception, part 3-clause BSD"
 build:   [make "unix-build"]
 install: [make "unix-install"   "PREFIX=%{prefix}%"]
 remove:  [make "unix-uninstall" "PREFIX=%{prefix}%"]

--- a/mirage-xen.opam
+++ b/mirage-xen.opam
@@ -4,7 +4,7 @@ authors:      "The MirageOS team"
 homepage:     "https://github.com/mirage/mirage-platform"
 bug-reports:  "https://github.com/mirage/mirage-platform/issues/"
 dev-repo:     "https://github.com/mirage/mirage-platform.git"
-license:      "part ISC, part LBPL-2.1 with OCaml linking ecxeption, part 3-clause BSD"
+license:      "part ISC, part LGPL-2.1 with OCaml linking exception, part 3-clause BSD"
 
 build:   [make "xen-build"]
 install: [make "xen-install"   "PREFIX=%{prefix}%"]


### PR DESCRIPTION
s/LBPL/LGPL/g
s/ecxeption/exception/g

Signed-off-by: David Scott <dave@recoil.org>