### PR TITLE
Update cstruct_stubs.c from 2.0.0

### DIFF
--- a/bindings/cstruct_stubs.c
+++ b/bindings/cstruct_stubs.c
@@ -19,6 +19,7 @@
 #include <stdlib.h>
 #include <errno.h>
 #include <string.h>
+#include <stdint.h>
 
 #include <caml/mlvalues.h>
 #include <caml/memory.h>
@@ -68,4 +69,12 @@ caml_fill_bigstring(value val_buf, value val_ofs, value val_len, value val_byte)
          Int_val(val_byte),
          Long_val(val_len));
   return Val_unit;
+}
+
+CAMLprim value
+caml_check_alignment_bigstring(value val_buf, value val_ofs, value val_alignment)
+{
+  uint64_t address = (uint64_t) (Caml_ba_data_val(val_buf) + Long_val(val_ofs));
+  int alignment = Int_val(val_alignment);
+  return Val_bool(address % alignment == 0);
 }


### PR DESCRIPTION
Since this adds a new binding, it's a backwards-compatible change.

Fixes [mirage/mirage#538]

Signed-off-by: David Scott <dave@recoil.org>