### PR TITLE
for compiler version 4.04, set OCAML_OS_TYPE to "xen"

### DIFF
--- a/xen-ocaml/build.sh
+++ b/xen-ocaml/build.sh
@@ -55,6 +55,7 @@ case `ocamlopt -version` in
   echo Applying OCaml 4.04 config
   cp config/version-404.h ocaml-src/byterun/caml/version.h
   patch < clambda-warnings.patch -p 0
+  patch < os-type-xen.patch -p 0
 esac
 
 cp config/s.h ocaml-src/config/

--- a/xen-ocaml/os-type-xen.patch
+++ b/xen-ocaml/os-type-xen.patch
@@ -1,0 +1,10 @@
+define OCAML_OS_TYPE as "xen".  Only a good idea for compiler versions >= 4.04.0.
+See https://github.com/mirage/mirage-platform/pull/78/ .
+--- config/s.h
++++ config/s.h
+@@ -1,4 +1,4 @@
+-#define OCAML_OS_TYPE "Unix"
++#define OCAML_OS_TYPE "xen"
+ #define OCAML_STDLIB_DIR "/usr/local/lib/ocaml"
+ #define POSIX_SIGNALS
+ //#define HAS_GETRUSAGE


### PR DESCRIPTION
We no longer need to falsely claim to be Unix.