### PR TITLE
Avoid memsetting NULL

### DIFF
--- a/xen-posix/src/mini_libc.c
+++ b/xen-posix/src/mini_libc.c
@@ -72,7 +72,7 @@ void* calloc(size_t nmemb, size_t _size)
 {
   register size_t size=_size*nmemb;
   void* x=malloc(size);
-  memset(x,0,size);
+  if (x) memset(x,0,size);
   return x;
 }
 


### PR DESCRIPTION
Fix "Page fault at linear address 0" that occurred to me a few times.