### PR TITLE
Fix mirage-xen on OCaml 4.05

### DIFF
--- a/xen-ocaml/build.sh
+++ b/xen-ocaml/build.sh
@@ -50,8 +50,8 @@ case `ocamlopt -version` in
 4.05.*)
   echo Applying OCaml 4.05 config
   cp config/version-405.h ocaml-src/byterun/caml/version.h
-  BIGARRAY_OBJ=""
-  CFLAGS="-D__ANDROID__"
+  BIGARRAY_OBJ="mmap_unix.o"
+  CFLAGS="-D__ANDROID__ $CFLAGS"
   ;;
 *)
   echo unsupported OCaml version `ocamlopt -version`


### PR DESCRIPTION
I don't understand why the build script wants to do things differently for 4.05, but reverting these two changes (erasing `BIGARRAY_OBJ` and `CFLAGS`) allowed hello world to work for me on 4.05!

/cc @avsm

Fixes #194.