### PR TITLE
Do not use opam config exec

### DIFF
--- a/xen-ocaml/build.sh
+++ b/xen-ocaml/build.sh
@@ -37,7 +37,7 @@ CFLAGS="-Wall -Wno-attributes ${ARCH_CFLAGS} ${EXTRA_CFLAGS} ${CI_CFLAGS} -DSYS_
   "
 
 rm -rf ocaml-src
-cp -r `opam config exec -- ocamlfind query ocaml-src` ocaml-src
+cp -r `ocamlfind query ocaml-src` ocaml-src
 chmod -R u+w ocaml-src
 
 echo Detected OCaml version `ocamlopt -version`


### PR DESCRIPTION
When invoking `ocamlfind`. The environment should be setup correctly, I believe, and on opam2 this will fail due to the sandbox preventing `opam config exec` writing logs.

Fixes #200 