### PR TITLE
Fix flags generation.

### DIFF
--- a/xen-ocaml/build.sh
+++ b/xen-ocaml/build.sh
@@ -144,5 +144,5 @@ ar rcs ../../libxenotherlibs.a ${BIGARRAY_OBJ}
 
 cd ../../..
 
-echo "($(pkg-config libminios-xen --libs)$(pkg-config openlibm --libs)$(cat flags/libs.tmp))" > flags/libs
-echo "($(pkg-config libminios-xen --cflags)$(pkg-config openlibm --cflags)$(cat flags/cflags.tmp))" > flags/cflags
+echo "($(cat flags/libs.tmp) -cclib \"$(pkg-config libminios-xen openlibm --libs | xargs)\")" > flags/libs
+echo "($(pkg-config libminios-xen openlibm --cflags | xargs) $(cat flags/cflags.tmp))" > flags/cflags

--- a/xen-ocaml/flags/libs.tmp.in
+++ b/xen-ocaml/flags/libs.tmp.in
@@ -1,1 +1,1 @@
-%{mirage-xen-ocaml:lib}%/libxenasmrun.a %{mirage-xen-ocaml:lib}%/libxenotherlibs.a %{mirage-xen-posix:lib}%/libxenposix.a
+-I %{mirage-xen-ocaml:lib}% -cclib "%{mirage-xen-ocaml:lib}%/libasmrunxen.a %{mirage-xen-ocaml:lib}%/libxenotherlibs.a %{mirage-xen-posix:lib}%/libxenposix.a"

--- a/xen-ocaml/install.sh
+++ b/xen-ocaml/install.sh
@@ -5,6 +5,7 @@ if [ "$prefix" = "" ]; then
   prefix=`opam config var prefix`
 fi
 
+OCAML_LIB_DIR=$(ocamlopt -config )
 OCAMLOPT_VERSION=$(ocamlopt -version)
 echo Detected OCaml version $OCAMLOPT_VERSION
 case $OCAMLOPT_VERSION in
@@ -22,8 +23,7 @@ odir=$prefix/lib
 mkdir -p $odir/mirage-xen-ocaml
 #We dont install the bytecode version yet
 #cd ocaml-src/byterun && make install LIBDIR="${pwd}/obj" BINDIR="${pwd}/obj"
-cp ocaml-src/$ASMRUN_FOLDER/libasmrun.a $odir/mirage-xen-ocaml/libxenasmrun.a
-ln -s $odir/mirage-xen-ocaml/libxenasmrun.a $odir/ocaml/libasmrunxen.a
+cp ocaml-src/$ASMRUN_FOLDER/libasmrun.a $odir/mirage-xen-ocaml/libasmrunxen.a
 cp ocaml-src/libxenotherlibs.a $odir/mirage-xen-ocaml/libxenotherlibs.a
 cp flags/cflags $odir/mirage-xen-ocaml/
 cp flags/libs $odir/mirage-xen-ocaml/

--- a/xen-ocaml/mirage-xen-ocaml.pc
+++ b/xen-ocaml/mirage-xen-ocaml.pc
@@ -8,6 +8,6 @@ Version: 1.0.0
 URL: https://github.com/mirage/mirage-platform/
 Description: OCaml runtime compiled for Mirage Xen
 Cflags: -I${includedir}
-Libs: ${libdir}/mirage-xen-ocaml/libxenasmrun.a ${libdir}/mirage-xen-ocaml/libxenotherlibs.a
+Libs: ${libdir}/mirage-xen-ocaml/libasmrunxen.a ${libdir}/mirage-xen-ocaml/libxenotherlibs.a
 Requires: mirage-xen-posix
 

--- a/xen-ocaml/uninstall.sh
+++ b/xen-ocaml/uninstall.sh
@@ -5,8 +5,9 @@ if [ "$prefix" = "" ]; then
   prefix=`opam config var prefix`
 fi
 
+OCAML_LIB_DIR=$(opam config var stublibs)
 odir=$prefix/lib
 rm -f $odir/pkgconfig/mirage-xen-ocaml.pc
 rm -rf $odir/mirage-xen-ocaml
 rm -rf $prefix/include/mirage-xen-ocaml
-rm -f $odir/ocaml/libasmrunxen.a
+rm -f $OCAML_LIB_DIR/libasmrunxen.a

--- a/xen-posix/build.sh
+++ b/xen-posix/build.sh
@@ -38,7 +38,7 @@ CFLAGS="$EXTRA_CFLAGS ${CI_CFLAGS} -I ${PWD}/include/ -I ${PWD}/src/ \
 ${CC} -c ${CFLAGS} src/*.c
 ar rcs libxenposix.a mini_libc.o fmt_fp.o dtoa.o strtol.o
 
-echo "($(pkg-config libminios-xen --libs)$(pkg-config openlibm --libs)$(cat flags/minios-libs.tmp))" > flags/minios-libs
-echo "($(pkg-config libminios-xen --cflags)$(pkg-config openlibm --cflags)$(cat flags/minios-cflags.tmp))" > flags/minios-cflags
-echo "($(pkg-config libminios-xen --libs)$(pkg-config openlibm --libs)$(cat flags/posix-libs.tmp))" > flags/posix-libs
-echo "($(pkg-config libminios-xen --cflags)$(pkg-config openlibm --cflags)$(cat flags/posix-cflags.tmp))" > flags/posix-cflags
+echo "(-cclib \"$(pkg-config libminios-xen openlibm --libs | xargs)\" $(cat flags/minios-libs.tmp))" > flags/minios-libs
+echo "($(pkg-config libminios-xen openlibm --cflags | xargs) $(cat flags/minios-cflags.tmp))" > flags/minios-cflags
+echo "(-cclib \"$(pkg-config libminios-xen openlibm --libs | xargs)\" $(cat flags/posix-libs.tmp))" > flags/posix-libs
+echo "($(pkg-config libminios-xen openlibm --cflags | xargs) $(cat flags/posix-cflags.tmp))" > flags/posix-cflags

--- a/xen-posix/flags/minios-libs.tmp.in
+++ b/xen-posix/flags/minios-libs.tmp.in
@@ -1,1 +1,1 @@
-%{mirage-xen-posix:lib}%/libxenposix.a
+-cclib %{mirage-xen-posix:lib}%/libxenposix.a

--- a/xen-posix/flags/posix-libs.tmp.in
+++ b/xen-posix/flags/posix-libs.tmp.in
@@ -1,1 +1,1 @@
-%{mirage-xen-posix:lib}%/libxenposix.a
+-cclib %{mirage-xen-posix:lib}%/libxenposix.a


### PR DESCRIPTION
Flag file generation was broken for some distros such as Ubuntu: the concatenation of outputs was missing a space between flags.
Now the `libs` file is intended to be used directly as an option to ocamlopt. Finally `libxenasmrun.a` is renamed to `libasmrunxen.a` and we don't need to install it in the ocaml directory anymore.